### PR TITLE
Fix handling of symlinks causing directory tree recursion to break

### DIFF
--- a/scripts/inc/process.class.php
+++ b/scripts/inc/process.class.php
@@ -532,7 +532,9 @@ class Process {
 		}
 		
 		else {
-			$split[$this->_col_path] = explode(' ', $split[$this->_col_path], 2)[0];
+			if ($split[$this->_col_type] == 'l') {
+				$split[$this->_col_path] = explode(' -> ', $split[$this->_col_path], 2)[0];
+			}
 
 			// Only if all the checks passed.
 			$ret = $split;

--- a/scripts/inc/process.class.php
+++ b/scripts/inc/process.class.php
@@ -532,6 +532,8 @@ class Process {
 		}
 		
 		else {
+			$split[$this->_col_path] = explode(' ', $split[$this->_col_path], 2)[0];
+
 			// Only if all the checks passed.
 			$ret = $split;
 		}


### PR DESCRIPTION
This should fix issue: #8 

symlinks are stored in the data file as:

`l 2017-09-24 18:41:05 30 <srcdir>/extlinux.conf -> ../boot/extlinux/extlinux.conf`

the destination ` -> ../boot/extlinux/extlinux.conf` breaks traversal of the directory tree, causing subdirectory placement to put directories in the wrong location.

This fix strips out the destination leaving just the symlink filename